### PR TITLE
将对ULONG的打印从%d更改为%u

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vs/**
 **/x64/**
 **/.vscode/**
+PocUserPanel/obj/*
+*.log

--- a/Poc/CommPort.c
+++ b/Poc/CommPort.c
@@ -256,7 +256,7 @@ NTSTATUS PocMessageNotifyCallback(
 					DosProcessName,
 					wcslen(DosProcessName));
 
-				PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("%s->Add process rules success. DosProcessName = %ws Access = %d.\n", __FUNCTION__,
+				PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("%s->Add process rules success. DosProcessName = %ws Access = %u.\n", __FUNCTION__,
 					ProcessRules->ProcessName,
 					ProcessRules->Access));
 

--- a/Poc/FileFuncs.c
+++ b/Poc/FileFuncs.c
@@ -500,7 +500,10 @@ NTSTATUS PocCreateFileForEncTailer(
 
         Status = POC_FILE_HAS_ENCRYPTION_TAILER;
 
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\n%s->File %ws has encryption tailer FileSize = %d ProcessName = %ws.\n",
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\n%s@%s@%d: %s->File %ws has encryption tailer FileSize = %u ProcessName = %ws.\n",
+            __FUNCTION__,
+            __FILE__,
+            __LINE__,
             __FUNCTION__,
             StreamContext->FileName,
             FileSize,
@@ -1209,7 +1212,10 @@ NTSTATUS PocReentryToEncrypt(
         goto EXIT;
     }
 
-    PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\n%s->success. FileName = %ws FileSize = %d.\n",
+    PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\n%s@%s@%d: %s->success. FileName = %ws FileSize = %u.\n",
+        __FUNCTION__,
+        __FILE__,
+        __LINE__,
         __FUNCTION__,
         FileName,
         ((PFSRTL_ADVANCED_FCB_HEADER)(FileObject->FsContext))->FileSize.LowPart));
@@ -1489,7 +1495,7 @@ NTSTATUS PocReentryToDecrypt(
     ExReleaseResourceAndLeaveCriticalRegion(StreamContext->Resource);
     
 
-    PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("%s->success. FileName = %ws FileSize = %d.\n\n",
+    PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("%s->success. FileName = %ws FileSize = %u.\n\n",
         __FUNCTION__,
         FileName,
         ((PFSRTL_ADVANCED_FCB_HEADER)(FileObject->FsContext))->FileSize.LowPart));

--- a/Poc/FileInfo.c
+++ b/Poc/FileInfo.c
@@ -74,9 +74,6 @@ PocPreQueryInformationOperation(
     }
 
 
-    /*PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\nPocPreQueryInformationOperation->enter FileInformationClass = %d ProcessName = %ws File = %ws.\n",
-        Data->Iopb->Parameters.QueryFileInformation.FileInformationClass,
-        ProcessName, StreamContext->FileName));*/
 
     *CompletionContext = StreamContext;
     Status = FLT_PREOP_SUCCESS_WITH_CALLBACK;

--- a/Poc/Poc.vcxproj
+++ b/Poc/Poc.vcxproj
@@ -66,6 +66,7 @@
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>WDM</DriverType>
+    <Driver_SpectreMitigation>false</Driver_SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>

--- a/Poc/ProcesSecure.c
+++ b/Poc/ProcesSecure.c
@@ -761,14 +761,6 @@ OB_PREOP_CALLBACK_STATUS PocPreObjectOperation(
 		if (FlagOn(OperationInformation->Parameters->CreateHandleInformation.OriginalDesiredAccess,
 			PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE))
 		{
-			/*PT_DBG_PRINT(PTDBG_TRACE_ROUTINES,
-				("%s->Handle create ProcessId = %I64d ProcessName = %ws RequestProcessId = %I64d Kernel = %d access denied.\n",
-					__FUNCTION__,
-					(LONGLONG)ProcessId,
-					NULL != OutProcessInfo->OwnedProcessRule ?
-					OutProcessInfo->OwnedProcessRule->ProcessName : NULL,
-					(LONGLONG)RequestProcessId,
-					OperationInformation->KernelHandle));*/
 		}
 
 	}
@@ -793,14 +785,6 @@ OB_PREOP_CALLBACK_STATUS PocPreObjectOperation(
 		if (FlagOn(OperationInformation->Parameters->CreateHandleInformation.OriginalDesiredAccess,
 			PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE))
 		{
-			/*PT_DBG_PRINT(PTDBG_TRACE_ROUTINES,
-				("%s->Handle duplicate ProcessId = %I64d ProcessName = %ws RequestProcessId = %I64d Kernel = %d access denied.\n",
-					__FUNCTION__,
-					(LONGLONG)ProcessId,
-					NULL != OutProcessInfo->OwnedProcessRule ?
-					OutProcessInfo->OwnedProcessRule->ProcessName : NULL,
-					(LONGLONG)RequestProcessId,
-					OperationInformation->KernelHandle));*/
 		}
 			
 	}
@@ -907,15 +891,6 @@ VOID PocProcessNotifyRoutineEx(
 
 		OutProcessInfo->ProcessId = ProcessId;
 
-		/*PT_DBG_PRINT(PTDBG_TRACE_ROUTINES,
-			("%s->Add ProcessName = %ws ProcessId = %I64d Access = %d success.\n",
-				__FUNCTION__,
-				uProcessName->Buffer,
-				(LONGLONG)ProcessId,
-				OutProcessRules->Access));*/
-
-
-		
 	}
 
 EXIT:
@@ -1167,7 +1142,7 @@ NTSTATUS PocProcessInit()
 		OutProcessInfo->ProcessId = ProcessInfo->UniqueProcessId;
 
 		PT_DBG_PRINT(PTDBG_TRACE_ROUTINES,
-			("%s->Add ProcessName = %ws ProcessId = %I64d Access = %d success.\n",
+			("%s->Add ProcessName = %ws ProcessId = %I64d Access = %u success.\n",
 				__FUNCTION__,
 				uProcessName->Buffer,
 				(LONGLONG)ProcessInfo->UniqueProcessId,

--- a/Poc/Process.c
+++ b/Poc/Process.c
@@ -527,7 +527,10 @@ NTSTATUS PocFindProcessRulesNodeByName(
 
 			if (Remove)
 			{
-				PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("%s->Remove process = %ws Access = %d.\n",
+				PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("%s@%s@%d: %s->Remove process = %ws Access = %u.\n",
+					__FUNCTION__,
+					__FILE__,
+					__LINE__,
 					__FUNCTION__,
 					ProcessRules->ProcessName,
 					ProcessRules->Access));

--- a/Poc/Read.c
+++ b/Poc/Read.c
@@ -94,13 +94,7 @@ PocPreReadOperation(
         goto ERROR;
     }
 
-    
-    //PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\nPocPreReadOperation->enter StartingVbo = %d Length = %d ProcessName = %ws File = %ws.\n NonCachedIo = %d PagingIo = %d\n",
-    //    Data->Iopb->Parameters.Read.ByteOffset.LowPart,
-    //    Data->Iopb->Parameters.Read.Length,
-    //    ProcessName, StreamContext->FileName,
-    //    NonCachedIo,
-    //    PagingIo));
+
     
 
     StartingVbo = Data->Iopb->Parameters.Read.ByteOffset.LowPart;
@@ -117,7 +111,7 @@ PocPreReadOperation(
 
     if (!NonCachedIo && StartingVbo + ByteCount > StreamContext->FileSize)
     {
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreReadOperation->%ws cachedio read end of file Length = %d. NewLength = %d\n", 
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreReadOperation->%ws cachedio read end of file Length = %u. NewLength = %u\n", 
             ProcessName, 
             Data->Iopb->Parameters.Read.Length,
             StreamContext->FileSize - StartingVbo));
@@ -599,14 +593,7 @@ PocPostReadOperation(
 
         Status = PocGetProcessName(Data, ProcessName);
 
-        /*PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPostReadOperation->Decrypt success. StartingVbo = %d Length = %d ProcessName = %ws File = %ws.\n\n",
-            StartingVbo,
-            LengthReturned,
-            ProcessName, 
-            StreamContext->FileName));*/
-
-
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPostReadOperation->Decrypt success. StartingVbo = %d Length = %d ProcessName = %s\n",
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPostReadOperation->Decrypt success. StartingVbo = %u Length = %u ProcessName = %s\n",
             StartingVbo,
             LengthReturned,
             ProcessName));

--- a/Poc/Write.c
+++ b/Poc/Write.c
@@ -99,16 +99,9 @@ PocPreWriteOperation(
     Status = PocGetProcessName(Data, ProcessName);
 
 
-    //PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("\nPocPreWriteOperation->enter StartingVbo = %d Length = %d ProcessName = %ws File = %ws.\n NonCachedIo = %d PagingIo = %d\n",
-    //    Data->Iopb->Parameters.Write.ByteOffset.LowPart,
-    //    Data->Iopb->Parameters.Write.Length,
-    //    ProcessName, StreamContext->FileName,
-    //    NonCachedIo,
-    //    PagingIo));
-
     if (POC_RENAME_TO_ENCRYPT == StreamContext->Flag)
     {
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->leave PostClose will encrypt the file. StartingVbo = %d ProcessName = %ws File = %ws.\n",
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->leave PostClose will encrypt the file. StartingVbo = %u ProcessName = %ws File = %ws.\n",
             Data->Iopb->Parameters.Write.ByteOffset.LowPart, ProcessName, StreamContext->FileName));
         Status = FLT_PREOP_SUCCESS_NO_CALLBACK;
         goto ERROR;
@@ -118,7 +111,7 @@ PocPreWriteOperation(
     if (FltObjects->FileObject->SectionObjectPointer == StreamContext->ShadowSectionObjectPointers
         && NonCachedIo)
     {
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->Block StartingVbo = %d ProcessName = %ws File = %ws.\n",
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->Block StartingVbo = %u ProcessName = %ws File = %ws.\n",
             Data->Iopb->Parameters.Write.ByteOffset.LowPart, ProcessName, StreamContext->FileName));
 
         Data->IoStatus.Status = STATUS_SUCCESS;
@@ -172,7 +165,7 @@ PocPreWriteOperation(
             LengthReturned = FileSize - StartingVbo;
         }
 
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->RealToWrite = %d.\n", LengthReturned));
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->RealToWrite = %u.\n", LengthReturned));
         
         if (Data->Iopb->Parameters.Write.MdlAddress != NULL) 
         {
@@ -427,7 +420,7 @@ PocPreWriteOperation(
         }
 
 
-        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->Encrypt success. StartingVbo = %d Length = %d ProcessName = %ws File = %ws.\n\n",
+        PT_DBG_PRINT(PTDBG_TRACE_ROUTINES, ("PocPreWriteOperation->Encrypt success. StartingVbo = %u Length = %u ProcessName = %ws File = %ws.\n\n",
             Data->Iopb->Parameters.Write.ByteOffset.LowPart,
             LengthReturned,
             ProcessName,


### PR DESCRIPTION
`ULONG`的`print`输出应当使用`%u`格式，并删除了一些被注释的输出。